### PR TITLE
Fix bug with incorrect index in KillAllMinibossesAchievement

### DIFF
--- a/Content/Achievements/InfernumAchievements/KillAllMinibossesAchievement.cs
+++ b/Content/Achievements/InfernumAchievements/KillAllMinibossesAchievement.cs
@@ -28,7 +28,7 @@ namespace InfernumMode.Content.Achievements.InfernumAchievements
             [NPCID.BigMimicHallow] = MinibossesCompleted[3],
             [NPCID.DD2OgreT2] = MinibossesCompleted[5],
             [NPCID.DD2Betsy] = MinibossesCompleted[0],
-            [ModContent.NPCType<NuclearTerror>()] = MinibossesCompleted[8],
+            [ModContent.NPCType<NuclearTerror>()] = MinibossesCompleted[9],
         };
         #endregion
 


### PR DESCRIPTION
Fixed the bug where Nuclear Terror didn’t show up as the next kill target