### PR TITLE
Improved the use of tML's Localization system for in-game strings

### DIFF
--- a/Common/UtilityMethods/DrawingUtilities.cs
+++ b/Common/UtilityMethods/DrawingUtilities.cs
@@ -525,7 +525,7 @@ namespace InfernumMode
             {
                 float colorInterpolant = (float)(Math.Sin(Pi * Main.GlobalTimeWrappedHourly + 1f) * 0.5) + 0.5f;
                 Color c = CalamityUtils.MulticolorLerp(colorInterpolant, new Color(170, 0, 0, 255), Color.OrangeRed, new Color(255, 200, 0, 255));
-                return CalamityUtils.ColorMessage("Imbued with the infernal flames of a defeated foe", c);
+                return CalamityUtils.ColorMessage(GetLocalization("Items.InfernalRelicText").Value, c);
             }
         }
 

--- a/Content/BehaviorOverrides/AbyssAIs/DepthFeeder.cs
+++ b/Content/BehaviorOverrides/AbyssAIs/DepthFeeder.cs
@@ -60,7 +60,7 @@ namespace InfernumMode.Content.BehaviorOverrides.AbyssAIs
         {
             bestiaryEntry.Info.AddRange(new IBestiaryInfoElement[]
             {
-                new FlavorTextBestiaryInfoElement("Even in the overwhelmingly hostile environment of the Abyss, ecosystems may flourish.")
+                new FlavorTextBestiaryInfoElement("Mods.InfernumMode.Bestiary.DepthFeeder")
             });
         }
 

--- a/Content/BehaviorOverrides/AbyssAIs/Herring.cs
+++ b/Content/BehaviorOverrides/AbyssAIs/Herring.cs
@@ -61,7 +61,7 @@ namespace InfernumMode.Content.BehaviorOverrides.AbyssAIs
         {
             bestiaryEntry.Info.AddRange(new IBestiaryInfoElement[]
             {
-                new FlavorTextBestiaryInfoElement("Unusually hardy, these creatures somehow flourish in the toxic upper abyssal caverns. Regardless, they are at the bottom of the food chain.")
+                new FlavorTextBestiaryInfoElement("Mods.InfernumMode.Bestiary.Herring")
             });
         }
 

--- a/Content/BehaviorOverrides/AbyssAIs/LionfishEnemy.cs
+++ b/Content/BehaviorOverrides/AbyssAIs/LionfishEnemy.cs
@@ -44,7 +44,7 @@ namespace InfernumMode.Content.BehaviorOverrides.AbyssAIs
         {
             bestiaryEntry.Info.AddRange(new IBestiaryInfoElement[]
             {
-                new FlavorTextBestiaryInfoElement("These rugged fish are seldom hunted in their natural habitats, relying heavily on their venomous spines for both offense and defense.")
+                new FlavorTextBestiaryInfoElement("Mods.InfernumMode.Bestiary.Lionfish")
             });
         }
 

--- a/Content/BehaviorOverrides/BossAIs/CalamitasShadow/CalamitasShadowBehaviorOverride.cs
+++ b/Content/BehaviorOverrides/BossAIs/CalamitasShadow/CalamitasShadowBehaviorOverride.cs
@@ -33,6 +33,7 @@ using Terraria.GameContent;
 using Terraria.Graphics.Effects;
 using Terraria.Graphics.Shaders;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 using CalamitasShadowBoss = CalamityMod.NPCs.CalClone.CalamitasClone;
 using SCalBoss = CalamityMod.NPCs.SupremeCalamitas.SupremeCalamitas;
@@ -187,11 +188,11 @@ namespace InfernumMode.Content.BehaviorOverrides.BossAIs.CalamitasShadow
 
         public static Color TextColor => Color.Lerp(Color.MediumPurple, Color.Black, 0.32f);
 
-        public const string CustomName = "Forgotten Shadow of Calamitas";
+        public static LocalizedText CustomName = Utilities.GetLocalization("NPCs.CalamitasShadowClone.DisplayName");
 
-        public const string CustomNameCataclysm = "Forgotten Shadow of Cataclysm";
+        public static LocalizedText CustomNameCataclysm = Utilities.GetLocalization("NPCs.CataclysmShadow.DisplayName");
 
-        public const string CustomNameCatastrophe = "Forgotten Shadow of Catastrophe";
+        public static LocalizedText CustomNameCatastrophe = Utilities.GetLocalization("NPCs.CatastropheShadow.DisplayName");
 
         public override bool PreAI(NPC npc)
         {

--- a/Content/BehaviorOverrides/BossAIs/GreatSandShark/BereftVassal.cs
+++ b/Content/BehaviorOverrides/BossAIs/GreatSandShark/BereftVassal.cs
@@ -207,7 +207,7 @@ namespace InfernumMode.Content.BehaviorOverrides.BossAIs.GreatSandShark
             bestiaryEntry.Info.AddRange(new IBestiaryInfoElement[]
             {
                 BestiaryDatabaseNPCsPopulator.CommonTags.SpawnConditions.Biomes.Desert,
-                new FlavorTextBestiaryInfoElement("A vigilant guardian, once wandering without a purpose. Having learned that his king lives on, it'd seem that he has started to regain his will to live. He looks forward to fighting you again.")
+                new FlavorTextBestiaryInfoElement("Mods.InfernumMode.Bestiary.BereftVassal")
             });
         }
 

--- a/Content/BehaviorOverrides/BossAIs/GreatSandShark/GreatSandSharkBehaviorOverride.cs
+++ b/Content/BehaviorOverrides/BossAIs/GreatSandShark/GreatSandSharkBehaviorOverride.cs
@@ -7,6 +7,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.Audio;
 using Terraria.GameContent;
+using Terraria.Localization;
 using Terraria.ModLoader;
 using GreatSandSharkNPC = CalamityMod.NPCs.GreatSandShark.GreatSandShark;
 
@@ -16,7 +17,7 @@ namespace InfernumMode.Content.BehaviorOverrides.BossAIs.GreatSandShark
     {
         public override int NPCOverrideType => ModContent.NPCType<GreatSandSharkNPC>();
 
-        public const string NewName = "Taurus, the Great Sand Shark";
+        public static LocalizedText NewName = Utilities.GetLocalization("NPCs.GreatSandShark.DisplayName");
 
         public override void Load()
         {

--- a/Content/Items/Accessories/SakuraBloom.cs
+++ b/Content/Items/Accessories/SakuraBloom.cs
@@ -37,23 +37,25 @@ namespace InfernumMode.Content.Items.Accessories
         {
             loveSparkles.RemoveAll(s => s.Time >= s.Lifetime);
             memorySparkles.RemoveAll(s => s.Time >= s.Lifetime);
+            
             if (line.Text.StartsWith("A symbol of how beautiful love is when in bloom, and how easily it can wither away"))
             {
                 Vector2 drawOffset = Vector2.UnitY * yOffset;
 
-                drawOffset.X += DrawLine(line, drawOffset, ref loveSparkles, "A symbol of how beautiful ");
+                drawOffset.X += DrawLine(line, drawOffset, ref loveSparkles, Utilities.GetLocalization("Items.SakuraBloom.TooltipEffect.FirstText").Value);
 
-                drawOffset.X += DrawLine(line, drawOffset, ref loveSparkles, "love", true);
+                drawOffset.X += DrawLine(line, drawOffset, ref loveSparkles, Utilities.GetLocalization("Items.SakuraBloom.TooltipEffect.SecondText").Value, true);
 
-                DrawLine(line, drawOffset, ref loveSparkles, " is when it’s in bloom, and yet how easily it can wither away");
+                DrawLine(line, drawOffset, ref loveSparkles, Utilities.GetLocalization("Items.SakuraBloom.TooltipEffect.ThirdText").Value);
                 return false;
             }
+            // Idk what is this for -marow
             else if (line.Text == "Temporary")
             {
                 Vector2 drawOffset = Vector2.UnitY * yOffset;
-                drawOffset.X += DrawLine(line, drawOffset, ref loveSparkles, "Maybe with this, we can hold onto the ");
-                drawOffset.X += DrawLine(line, drawOffset, ref memorySparkles, "memories", true, 12);
-                drawOffset.X += DrawLine(line, drawOffset, ref loveSparkles, "?");
+                drawOffset.X += DrawLine(line, drawOffset, ref loveSparkles, Utilities.GetLocalization("Items.SakuraBloom.TooltipEffect.FourthText").Value);
+                drawOffset.X += DrawLine(line, drawOffset, ref memorySparkles, Utilities.GetLocalization("Items.SakuraBloom.TooltipEffect.FifthText").Value, true, 12);
+                drawOffset.X += DrawLine(line, drawOffset, ref loveSparkles, Utilities.GetLocalization("Items.SakuraBloom.TooltipEffect.SixthText").Value);
                 return false;
             }
 

--- a/Content/Items/Misc/SakuraBud.cs
+++ b/Content/Items/Misc/SakuraBud.cs
@@ -55,20 +55,20 @@ namespace InfernumMode.Content.Items.Misc
             Vector2 drawOffset = Vector2.UnitY * yOffset;
             if (line.Text.StartsWith("You feel"))
             {                
-                drawOffset.X += SakuraBloom.DrawLine(line, drawOffset, ref spiritSparkles, "You feel a ");
-                drawOffset.X += SakuraBloom.DrawLine(line, drawOffset, ref spiritSparkles, "guiding spirit", true);
-                drawOffset.X += SakuraBloom.DrawLine(line, drawOffset, ref spiritSparkles, " trying to lead you the bloom’s home");
+                drawOffset.X += SakuraBloom.DrawLine(line, drawOffset, ref spiritSparkles, Utilities.GetLocalization("Items.SakuraBud.TooltipEffect.FirstText").Value);
+                drawOffset.X += SakuraBloom.DrawLine(line, drawOffset, ref spiritSparkles, Utilities.GetLocalization("Items.SakuraBud.TooltipEffect.SecondText").Value, true);
+                drawOffset.X += SakuraBloom.DrawLine(line, drawOffset, ref spiritSparkles, Utilities.GetLocalization("Items.SakuraBud.TooltipEffect.ThirdText").Value);
                 return false;
             }
             if (line.Text.StartsWith("Maybe you"))
             {
                 if (Main.LocalPlayer.WithinRange(WorldSaveSystem.BlossomGardenCenter.ToWorldCoordinates(), 3200f))
                 {
-                    drawOffset.X += SakuraBloom.DrawLine(line, drawOffset, ref waterSparkles, "The spirit is trying to draw your attention to the ");
-                    drawOffset.X += SakuraBloom.DrawLine(line, drawOffset, ref waterSparkles, "water", true, overrideColor: new(26, 169, 208));
+                    drawOffset.X += SakuraBloom.DrawLine(line, drawOffset, ref waterSparkles, Utilities.GetLocalization("Items.SakuraBud.TooltipEffect.FourthText").Value);
+                    drawOffset.X += SakuraBloom.DrawLine(line, drawOffset, ref waterSparkles, Utilities.GetLocalization("Items.SakuraBud.TooltipEffect.FifthText").Value, true, overrideColor: new(26, 169, 208));
                 }
                 else
-                    SakuraBloom.DrawLine(line, drawOffset, ref waterSparkles, "Maybe you should follow its call?");
+                    SakuraBloom.DrawLine(line, drawOffset, ref waterSparkles, Utilities.GetLocalization("Items.SakuraBud.TooltipEffect.SixthText").Value);
 
                 return false;            
             }

--- a/Content/Items/Misc/Wayfinder.cs
+++ b/Content/Items/Misc/Wayfinder.cs
@@ -80,9 +80,15 @@ namespace InfernumMode.Content.Items.Misc
 
                 if (l.Text.StartsWith("ModifedInModifyTooltips"))
                 {
-                    l.Text = $"Hold LMB to teleport to the gate" +
+                    /*l.Text = $"Hold LMB to teleport to the gate" +
                     $"\nHold LMB and {KeybindSystem.WayfinderCreateKey.GetAssignedKeys().FirstOrDefault() ?? "[NONE]"} to set the gate to your position" +
-                    $"\nHold LMB and {KeybindSystem.WayfinderDestroyKey.GetAssignedKeys().FirstOrDefault() ?? "[NONE]"} to remove the gate";
+                    $"\nHold LMB and {KeybindSystem.WayfinderDestroyKey.GetAssignedKeys().FirstOrDefault() ?? "[NONE]"} to remove the gate";*/
+
+                    l.Text = Utilities.GetLocalization("Items.Wayfinder.TooltipEffect")
+                        .Format(
+                            KeybindSystem.WayfinderCreateKey.GetAssignedKeys().FirstOrDefault() ?? "[NONE]",
+                            KeybindSystem.WayfinderDestroyKey.GetAssignedKeys().FirstOrDefault() ?? "[NONE]"
+                        );
                     l.OverrideColor = mainColor;
                 }
             }

--- a/Content/Items/Relics/DevourerOfGodsRelic.cs
+++ b/Content/Items/Relics/DevourerOfGodsRelic.cs
@@ -8,10 +8,8 @@ namespace InfernumMode.Content.Items.Relics
     public class DevourerOfGodsRelic : BaseRelicItem
     {
         public override string DisplayNameToUse => "Infernal Devourer of Gods Relic";
-
-        public override string PersonalMessage => "Sometimes pure reaction skill is the most valuable thing to cultivate.\n" +
-            "You are in the final stretch. Your determination has proven invaluable up to this point.\n" +
-            "May it guide you through the last challenges.";
+        
+        public override string PersonalMessage => Utilities.GetLocalization("Items.DevourerOfGodsRelic.PersonalMessage").Value;
 
         public override Color? PersonalMessageColor => Color.Lerp(Color.Cyan, Color.Fuchsia, Cos(Main.GlobalTimeWrappedHourly * 2.3f) * 0.5f + 0.5f);
 

--- a/Content/Items/Relics/DraedonRelic.cs
+++ b/Content/Items/Relics/DraedonRelic.cs
@@ -13,14 +13,11 @@ namespace InfernumMode.Content.Items.Relics
         {
             get
             {
-                if (DownedBossSystem.downedCalamitas)
-                {
-                    return "Spectacular work. You have conquered all of the major obstacles.\n" +
-                        "Take pride in this accomplishment, for you are considerably stronger than you were when you began.";
+                if (DownedBossSystem.downedCalamitas) {
+                    return Utilities.GetLocalization("Items.DraedonRelic.PersonalMessage.DownedCalamitasMessage").Value;
                 }
 
-                return "You have done phenomenally. There is only one challenge left now-\n" +
-                    "Face the Witch.";
+                return Utilities.GetLocalization("Items.DraedonRelic.PersonalMessage.DefaultMessage").Value;
             }
         }
 

--- a/Content/Items/Relics/EmpressOfLightRelic.cs
+++ b/Content/Items/Relics/EmpressOfLightRelic.cs
@@ -8,7 +8,7 @@ namespace InfernumMode.Content.Items.Relics
     {
         public override string DisplayNameToUse => "Infernal Empress of Light Relic";
 
-        public override string PersonalMessage => "The optional foes may at times be the most formidable. So too may they yield the greatest rewards.";
+        public override string PersonalMessage => Utilities.GetLocalization("Items.EmpressOfLightRelic.PersonalMessage").Value;
 
         public override Color? PersonalMessageColor => Color.DeepPink;
 

--- a/Content/Items/Relics/EyeOfCthulhuRelic.cs
+++ b/Content/Items/Relics/EyeOfCthulhuRelic.cs
@@ -7,9 +7,8 @@ namespace InfernumMode.Content.Items.Relics
     public class EyeOfCthulhuRelic : BaseRelicItem
     {
         public override string DisplayNameToUse => "Infernal Eye of Cthulhu Relic";
-
-        public override string PersonalMessage => "Remember to not force yourself too much in the pursuit of victory. Take breaks if you need to.\n" +
-            "The most important thing is fun.";
+        
+        public override string PersonalMessage => Utilities.GetLocalization("Items.EyeOfCthulhuRelic.PersonalMessage").Value;
 
         public override Color? PersonalMessageColor => Color.LightGray;
 

--- a/Content/Items/Relics/ForgottenShadowOfCalamitasRelic.cs
+++ b/Content/Items/Relics/ForgottenShadowOfCalamitasRelic.cs
@@ -7,7 +7,7 @@ namespace InfernumMode.Content.Items.Relics
     [LegacyName("CalamitasCloneRelic")]
     public class ForgottenShadowOfCalamitasRelic : BaseRelicItem
     {
-        public override string DisplayNameToUse => $"Infernal {CalamitasShadowBehaviorOverride.CustomName} Relic";
+        public override string DisplayNameToUse => "Infernal" + CalamitasShadowBehaviorOverride.CustomName.Value + "Relic";
 
         public override int TileID => ModContent.TileType<ForgottenShadowOfCalamitasRelicTile>();
     }

--- a/Content/Items/Relics/GolemRelic.cs
+++ b/Content/Items/Relics/GolemRelic.cs
@@ -8,7 +8,7 @@ namespace InfernumMode.Content.Items.Relics
     {
         public override string DisplayNameToUse => "Infernal Golem Relic";
 
-        public override string PersonalMessage => "Simple methodical planning goes a long way. It will be invaluable against future obstacles.";
+        public override string PersonalMessage => Utilities.GetLocalization("Items.GolemRelic.PersonalMessage").Value;
 
         public override Color? PersonalMessageColor => Color.Lerp(Color.Orange, Color.Brown, 0.4f);
 

--- a/Content/Items/Relics/KingSlimeRelic.cs
+++ b/Content/Items/Relics/KingSlimeRelic.cs
@@ -8,7 +8,7 @@ namespace InfernumMode.Content.Items.Relics
     {
         public override string DisplayNameToUse => "Infernal King Slime Relic";
 
-        public override string PersonalMessage => "Even seasoned players may struggle somewhat in the face of something new and unfamiliar. Adaptability is key.";
+        public override string PersonalMessage => Utilities.GetLocalization("Items.KingSlimeRelic.PersonalMessage").Value;
 
         public override Color? PersonalMessageColor => Color.Lerp(Color.DeepSkyBlue, Color.LightGray, 0.6f);
 

--- a/Content/Items/Relics/MoonLordRelic.cs
+++ b/Content/Items/Relics/MoonLordRelic.cs
@@ -8,7 +8,7 @@ namespace InfernumMode.Content.Items.Relics
     {
         public override string DisplayNameToUse => "Infernal Moon Lord Relic";
 
-        public override string PersonalMessage => "You have done very well thus far.\nMay your tenacity guide you through the remaining challenges.";
+        public override string PersonalMessage => Utilities.GetLocalization("Items.GolemRelic.PersonalMessage").Value;
 
         public override Color? PersonalMessageColor => Color.Lerp(Color.Cyan, Color.DarkGreen, 0.5f);
 

--- a/Content/Items/Relics/OldDukeRelic.cs
+++ b/Content/Items/Relics/OldDukeRelic.cs
@@ -8,9 +8,8 @@ namespace InfernumMode.Content.Items.Relics
     {
         public override string DisplayNameToUse => "Infernal Old Duke Relic";
 
-        public override string PersonalMessage => "Difficult as the fight may be, you were wise to endure and overcome the challenge it brings.\n" +
-            "You will find that the mechanics it tested will be relevant again soon.";
-
+        public override string PersonalMessage => Utilities.GetLocalization("Items.OldDukeRelic.PersonalMessage").Value;
+        
         public override Color? PersonalMessageColor => Color.Lerp(Color.Lime, Color.Yellow, 0.8f);
 
         public override int TileID => ModContent.TileType<OldDukeRelicTile>();

--- a/Content/Items/Relics/PlanteraRelic.cs
+++ b/Content/Items/Relics/PlanteraRelic.cs
@@ -8,8 +8,7 @@ namespace InfernumMode.Content.Items.Relics
     {
         public override string DisplayNameToUse => "Infernal Plantera Relic";
 
-        public override string PersonalMessage => "Be proud of your death count!\n" +
-            "The more you die, the more you're learning. Keep going!";
+        public override string PersonalMessage => Utilities.GetLocalization("Items.PlanteraRelic.PersonalMessage").Value;
 
         public override Color? PersonalMessageColor => Color.Lerp(Color.Lime, Color.White, 0.5f);
 

--- a/Content/Items/Relics/ProvidenceRelic.cs
+++ b/Content/Items/Relics/ProvidenceRelic.cs
@@ -15,12 +15,10 @@ namespace InfernumMode.Content.Items.Relics
             {
                 if (WorldSaveSystem.HasBeatenInfernumNightProvBeforeDay)
                 {
-                    return "Bruh? What the heck? Are you OK?\n" +
-                        "You were supposed to fight her at night AFTER beating her during the day first!";
+                    return Utilities.GetLocalization("Items.ProvidenceRelic.PersonalMessage.HasBeatenInfernumNightProvBeforeDayMessage").Value;
                 }
 
-                return "The first major hurdle following the defeat of the Moon Lord. Your triumph over her was by no means a small feat.\n" +
-                    "Perhaps consider fighting her again during the night for a special challenge?";
+                return Utilities.GetLocalization("Items.ProvidenceRelic.PersonalMessage.DefaultMessage").Value;
             }
         }
 

--- a/Content/Items/Relics/SkeletronRelic.cs
+++ b/Content/Items/Relics/SkeletronRelic.cs
@@ -8,7 +8,7 @@ namespace InfernumMode.Content.Items.Relics
     {
         public override string DisplayNameToUse => "Infernal Skeletron Relic";
 
-        public override string PersonalMessage => "The first major roadblock. You are better now than before you faced it. Did you have fun learning its patterns?";
+        public override string PersonalMessage => Utilities.GetLocalization("Items.SkeletronRelic.PersonalMessage").Value;
 
         public override Color? PersonalMessageColor => Color.Violet;
 

--- a/Content/Items/Relics/SupremeCalamitasRelic.cs
+++ b/Content/Items/Relics/SupremeCalamitasRelic.cs
@@ -15,12 +15,10 @@ namespace InfernumMode.Content.Items.Relics
             {
                 if (DownedBossSystem.downedExoMechs)
                 {
-                    return "Spectacular work. You have conquered all of the major obstacles.\n" +
-                        "Take pride in this accomplishment, for you are considerably stronger than you were when you began.";
+                    return Utilities.GetLocalization("Items.SupremeCalamitasRelic.PersonalMessage.DownedExoMechsMessage").Value;
                 }
 
-                return "You have done phenomenally. There is only one challenge left now-\n" +
-                    "Face the Cosmic Engineer.";
+                return Utilities.GetLocalization("Items.SupremeCalamitasRelic.PersonalMessage.DefaultMessage").Value;
             }
         }
 

--- a/Content/Items/Weapons/Magic/IllusionersReverie.cs
+++ b/Content/Items/Weapons/Magic/IllusionersReverie.cs
@@ -61,7 +61,7 @@ namespace InfernumMode.Content.Items.Weapons.Magic
             if (line.Name == "Tooltip1")
             {
                 Vector2 drawOffset = Vector2.UnitY * yOffset;
-                drawOffset.X += DrawLine(line, drawOffset, "An ");
+                drawOffset.X += DrawLine(line, drawOffset, Utilities.GetLocalization("Items.IllusionersReverie.TooltipEffect.FirstText").Value);
 
                 Main.spriteBatch.End();
                 Main.spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend, Main.SamplerStateForCursor, DepthStencilState.None, RasterizerState.CullCounterClockwise, null, Main.UIScaleMatrix);
@@ -74,12 +74,12 @@ namespace InfernumMode.Content.Items.Weapons.Magic
                 displacementShader.Shader.Parameters["noiseIntensity"].SetValue(2f);
                 displacementShader.Shader.Parameters["horizontalDisplacementFactor"].SetValue(0.0094f);
                 displacementShader.Apply();
-                drawOffset.X += DrawLine(line, drawOffset, "incomprehensibly ");
+                drawOffset.X += DrawLine(line, drawOffset, Utilities.GetLocalization("Items.IllusionersReverie.TooltipEffect.SecondText").Value);
 
                 Main.spriteBatch.End();
                 Main.spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, Main.SamplerStateForCursor, DepthStencilState.None, RasterizerState.CullCounterClockwise, null, Main.UIScaleMatrix);
 
-                drawOffset.X += DrawLine(line, drawOffset, "old tome. Somehow, in spite of its supposed age, it appears to be completely unscathed");
+                drawOffset.X += DrawLine(line, drawOffset, Utilities.GetLocalization("Items.IllusionersReverie.TooltipEffect.ThirdText").Value);
 
                 return false;
             }

--- a/Content/Projectiles/HyperplaneMatrixProjectile.cs
+++ b/Content/Projectiles/HyperplaneMatrixProjectile.cs
@@ -315,7 +315,7 @@ namespace InfernumMode.Content.Projectiles
             }
 
             // Hurt the player.
-            var hurtReason = PlayerDeathReason.ByCustomReason($"{Owner.name} was blown up.");
+            var hurtReason = PlayerDeathReason.ByCustomReason(Utilities.GetLocalization("Status.Death.HyperplaneMatrixExplosion").Format(Owner.name));
             Owner.Hurt(hurtReason, HyperplaneMatrix.UnableToBeUsedHurtDamage, 0);
 
             // Destroy the matrix.

--- a/Content/Tiles/Profaned/GuardiansPlaque.cs
+++ b/Content/Tiles/Profaned/GuardiansPlaque.cs
@@ -85,7 +85,7 @@ namespace InfernumMode.Content.Tiles.Profaned
 
             if (!GuardiansPlaqueUIManager.ShouldDraw)
             {
-                Main.LocalPlayer.cursorItemIconText = "Read";
+                Main.LocalPlayer.cursorItemIconText = Utilities.GetLocalization("UI.GuardiansPlaqueUI.HoverText").Value;
                 Main.instance.MouseTextHackZoom(Main.LocalPlayer.cursorItemIconText);
             }
         }

--- a/Content/UI/AchievementUIManager.cs
+++ b/Content/UI/AchievementUIManager.cs
@@ -65,7 +65,7 @@ namespace InfernumMode.Content.UI
             AchivementList.ListPadding = 5f;
             uIPanel.Append(AchivementList);
 
-            UITextPanel<LocalizedText> uITextPanel = new(Language.GetText("Death Wishes"), 1f, large: true)
+            UITextPanel<LocalizedText> uITextPanel = new(Utilities.GetLocalization("UI.AchievementsHeader"), 1f, large: true)
             {
                 HAlign = 0.5f
             };
@@ -221,7 +221,7 @@ namespace InfernumMode.Content.UI
             AchivementList.ListPadding = 5f;
             uIPanel.Append(AchivementList);
 
-            UITextPanel<LocalizedText> uITextPanel = new(Language.GetText("Dev Wishes"), 1f, large: true)
+            UITextPanel<LocalizedText> uITextPanel = new(Utilities.GetLocalization("UI.WishesHeader"), 1f, large: true)
             {
                 HAlign = 0.5f
             };

--- a/Content/UI/GuardiansPlaqueUIManager.cs
+++ b/Content/UI/GuardiansPlaqueUIManager.cs
@@ -13,6 +13,7 @@ using Terraria;
 using Terraria.Audio;
 using Terraria.GameContent;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace InfernumMode.Content.UI
@@ -28,10 +29,11 @@ namespace InfernumMode.Content.UI
         // If the player isn't within this range of the plaque, the UI will close.
         public static float DistanceThresholdToDrawUI => 100f;
 
-        public const string TextToDraw = "Three disciples. One mind. One deity. One purpose. Tempered by the holy flames of Providence, an ancient artifact is crystalized, with the sole purpose of initiating the Ritual at the cliff of this Temple.";
-
+        //public const string TextToDraw = "Three disciples. One mind. One deity. One purpose. Tempered by the holy flames of Providence, an ancient artifact is crystalized, with the sole purpose of initiating the Ritual at the cliff of this Temple.";
+        public static LocalizedText TextToDraw = Utilities.GetLocalization("UI.GuardiansPlaqueUI.PlaqueText");
+        
         // The part of the TextToDraw should be drawn separately.
-        public const string SpecialText = "ancient artifact";
+        public static LocalizedText SpecialText = Utilities.GetLocalization("UI.GuardiansPlaqueUI.SpecialText");
 
         public static float TextPadding => 30f;
 
@@ -92,7 +94,9 @@ namespace InfernumMode.Content.UI
             // Draw the background behind the text.
             spriteBatch.Draw(BackgroundTexture, plaqueDrawCenter, null, Color.White * Opacity, 0f, BackgroundTexture.Size() * 0.5f, 1f, 0, 0f);
 
-            foreach (string line in Utils.WordwrapString(TextToDraw, TextFont, maxTextLength, 100, out _))
+            string specialTextValue = SpecialText.Value;
+            
+            foreach (string line in Utils.WordwrapString(TextToDraw.Value, TextFont, maxTextLength, 100, out _))
             {
                 // If the line is undefined that means that the text has been exhausted, and we can safely leave this loop.
                 if (string.IsNullOrEmpty(line))
@@ -100,10 +104,10 @@ namespace InfernumMode.Content.UI
 
                 // Draw the line.
                 // If it contains the special line, draw it separately by splitting the surrounding lines.
-                if (line.Contains(SpecialText))
+                if (line.Contains(specialTextValue))
                 {
-                    List<string> splitLines = line.Split(SpecialText).ToList();
-                    splitLines.Insert(1, SpecialText);
+                    List<string> splitLines = line.Split(specialTextValue).ToList();
+                    splitLines.Insert(1, specialTextValue);
 
                     foreach (string line2 in splitLines)
                     {
@@ -125,7 +129,9 @@ namespace InfernumMode.Content.UI
             Color textColor = WayfinderSymbol.Colors[0];
             Vector2 textArea = TextFont.MeasureString(line) * TextScale;
             Rectangle textRectangle = new((int)textLeftDrawPosition.X, (int)textLeftDrawPosition.Y + 5, (int)textArea.X, (int)(0.667f * textArea.Y));
-            if (line == SpecialText)
+            string specialTextValue = SpecialText.Value;
+            
+            if (line == specialTextValue)
             {
                 textColor = CalamityUtils.ColorSwap(Color.HotPink, Color.Coral, 1.5f);
 
@@ -134,7 +140,7 @@ namespace InfernumMode.Content.UI
                 {
                     Player.noThrow = 2;
                     Main.HoverItem = new(ModContent.ItemType<ProfanedShard>());
-                    Main.hoverItemName = "Profaned Shard";
+                    Main.hoverItemName = Main.HoverItem.Name;
                 }
             }
 

--- a/Core/GlobalInstances/GlobalItems/TooltipChangeGlobalItem.cs
+++ b/Core/GlobalInstances/GlobalItems/TooltipChangeGlobalItem.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Terraria;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace InfernumMode.Core.GlobalInstances.GlobalItems
@@ -21,21 +22,21 @@ namespace InfernumMode.Core.GlobalInstances.GlobalItems
 
         public bool DeveloperItem;
 
-        public static Dictionary<int, string> EnrageTooltipReplacements => new()
+        public static Dictionary<int, LocalizedText> EnrageTooltipReplacements => new()
         {
-            [ModContent.ItemType<DecapoditaSprout>()] = "Enrages outside of the Mushroom biome",
-            [ItemID.WormFood] = "Enrages outside of the Corruption",
-            [ItemID.BloodySpine] = "Enrages outside of the Crimson",
-            [ModContent.ItemType<Teratoma>()] = "Enrages outside of the Corruption",
-            [ModContent.ItemType<BloodyWormFood>()] = "Enrages outside of the Crimson",
-            [ModContent.ItemType<Seafood>()] = "Enrages outside of the waters of the Sulphurous Sea",
+            [ModContent.ItemType<DecapoditaSprout>()] = Utilities.GetLocalization("UI.EnrageTooltipReplacements.DecapoditaSprout"),
+            [ItemID.WormFood] = Utilities.GetLocalization("UI.EnrageTooltipReplacements.WormFood"),
+            [ItemID.BloodySpine] = Utilities.GetLocalization("UI.EnrageTooltipReplacements.BloodySpine"),
+            [ModContent.ItemType<Teratoma>()] = Utilities.GetLocalization("UI.EnrageTooltipReplacements.Teratoma"),
+            [ModContent.ItemType<BloodyWormFood>()] = Utilities.GetLocalization("UI.EnrageTooltipReplacements.BloodyWormFood"),
+            [ModContent.ItemType<Seafood>()] = Utilities.GetLocalization("UI.EnrageTooltipReplacements.Seafood"),
             [ItemID.MechanicalEye] = null,
             [ItemID.MechanicalSkull] = null,
             [ItemID.MechanicalWorm] = null,
             [ItemID.ClothierVoodooDoll] = null,
-            [ModContent.ItemType<Abombination>()] = "Enrages outside of the Underground Jungle",
+            [ModContent.ItemType<Abombination>()] = Utilities.GetLocalization("UI.EnrageTooltipReplacements.Abombination"),
             [ModContent.ItemType<ExoticPheromones>()] = null,
-            [ModContent.ItemType<NecroplasmicBeacon>()] = "Enrages outside of the Underground",
+            [ModContent.ItemType<NecroplasmicBeacon>()] = Utilities.GetLocalization("UI.EnrageTooltipReplacements.NecroplasmicBeacon")
         };
 
         public override void ModifyTooltips(Item item, List<TooltipLine> tooltips)
@@ -65,18 +66,16 @@ namespace InfernumMode.Core.GlobalInstances.GlobalItems
 
             if (item.type == ItemID.CelestialSigil)
             {
-                string summoningText = "Summons the Moon Lord immediately\n" +
-                        "Creates an arena at the player's position\n" +
-                        "Not consumable.";
-                replaceTooltipText("Tooltip0", summoningText);
+                LocalizedText summoningText = Utilities.GetLocalization("Items.CelestialSigil.SummoningText");
+                replaceTooltipText("Tooltip0", summoningText.Value);
             }
 
             if (InfernumMode.CanUseCustomAIs && item.type == ModContent.ItemType<ProfanedShard>())
             {
                 bool inGarden = Main.LocalPlayer.Infernum_Biome().InProfanedArena;
-                string summoningText = "Summons the Profaned Guardians when used on the cliff in the profaned garden at the far right of the underworld during day";
+                LocalizedText summoningText = Utilities.GetLocalization("Items.ProfanedShard.SummoningText");
                 Color textColor = inGarden ? WayfinderSymbol.Colors[2] : Color.White;
-                replaceTooltipText("Tooltip1", summoningText, textColor);
+                replaceTooltipText("Tooltip0", summoningText.Value, textColor); // Same here, old tooltip: "Tooltip1"
 
                 // Remove the next line about an enrage condition.
                 tooltips.RemoveAll(x => x.Name == "Tooltip2" && x.Mod == "Terraria");
@@ -84,9 +83,8 @@ namespace InfernumMode.Core.GlobalInstances.GlobalItems
                 // Add a warning about the lack of a garden if it hasn't been generated yet.
                 if (!WorldSaveSystem.HasGeneratedProfanedShrine)
                 {
-                    TooltipLine warningTooltip = new(Mod, "Warning",
-                        "Your world does not currently have a Profaned Garden. Kill the Moon Lord again to generate it\n" +
-                        "Be sure to grab the Hell schematic first if you do this, as the garden might destroy the lab")
+                    LocalizedText gardenWarning = Utilities.GetLocalization("Items.ProfanedShard.GardenWarning");
+                    TooltipLine warningTooltip = new(Mod, "Warning", gardenWarning.Value)
                     {
                         OverrideColor = Color.Orange
                     };
@@ -96,28 +94,27 @@ namespace InfernumMode.Core.GlobalInstances.GlobalItems
 
             if (InfernumMode.CanUseCustomAIs && item.type == ModContent.ItemType<EyeofDesolation>())
             {
-                string summoningText = $"Summons the {CalamitasShadowBehaviorOverride.CustomName} when used during nighttime";
-                replaceTooltipText("Tooltip1", summoningText);
+                string summoningText = Utilities.GetLocalization("Items.EyeofDesolation.SummoningText").Format(CalamitasShadowBehaviorOverride.CustomName);
+                replaceTooltipText("Tooltip0", summoningText); // Old tooltip (duplicates the summon text with latest Calamity ver): "Tooltip1"
             }
 
             if (InfernumMode.CanUseCustomAIs && item.type == ModContent.ItemType<ProfanedCore>())
             {
-                string summoningText = "Summons Providence when used at the altar in the profaned temple at the far right of the underworld";
-                replaceTooltipText("Tooltip1", summoningText);
+                LocalizedText summoningText = Utilities.GetLocalization("Items.ProfanedCore.SummoningText");
+                replaceTooltipText("Tooltip0", summoningText.Value);
             }
 
             if (InfernumMode.CanUseCustomAIs && item.type == ModContent.ItemType<RuneofKos>() && WorldSaveSystem.ForbiddenArchiveCenter.X != 0)
             {
-                TooltipLine developerLine = new(Mod, "CVWarning", CalamityUtils.ColorMessage("The Ceaseless Void can only be fought in the Archives", Color.Magenta));
+                LocalizedText summoningText = Utilities.GetLocalization("Items.RuneofKos.DeveloperText");
+                TooltipLine developerLine = new(Mod, "CVWarning", CalamityUtils.ColorMessage(summoningText.Value, Color.Magenta));
                 tooltips.Add(developerLine);
             }
 
             if (InfernumMode.CanUseCustomAIs && item.type == ItemID.LihzahrdPowerCell)
             {
-                string summoningText = "Summons Golem when used at the Lihzhard Altar\n" +
-                    "Golem summons a rectangular arena around the altar\n" +
-                    "If the altar is inside of the temple solid tiles within the arena are broken";
-                replaceTooltipText("Tooltip0", summoningText);
+                LocalizedText summoningText = Utilities.GetLocalization("Items.LihzahrdPowerCell.SummoningText");
+                replaceTooltipText("Tooltip0", summoningText.Value);
             }
 
             if (item.type == ModContent.ItemType<SandstormsCore>())
@@ -127,14 +124,14 @@ namespace InfernumMode.Core.GlobalInstances.GlobalItems
                 {
                     if (WorldSaveSystem.HasGeneratedColosseumEntrance || SubworldSystem.IsActive<LostColosseum>())
                     {
-                        tooltip0.Text = "Opens a portal to the Lost Colosseum";
+                        tooltip0.Text = Utilities.GetLocalization("Items.SandstormsCore.PortalDetail").Value;
                         tooltip0.OverrideColor = Color.Lerp(Color.Orange, Color.Yellow, 0.55f);
                     }
 
                     // Warn the player about not having a colosseum entrance if it hasn't been generated yet.
                     else
                     {
-                        tooltip0.Text = "Your world does not currently have a Lost Gateway. Kill the Lunatic Cultist again to generate it.";
+                        tooltip0.Text = Utilities.GetLocalization("Items.SandstormsCore.GatewayWarning").Value;
                         tooltip0.OverrideColor = Color.Orange;
                     }
                 }
@@ -148,7 +145,8 @@ namespace InfernumMode.Core.GlobalInstances.GlobalItems
             if (DeveloperItem)
             {
                 Color devColor = CalamityUtils.ColorSwap(Color.OrangeRed, Color.DarkRed, 2f);
-                TooltipLine developerLine = new(Mod, "Developer", $"[c/{devColor.Hex3()}:~ Developer Item ~]");
+                //TooltipLine developerLine = new(Mod, "Developer", $"[c/{devColor.Hex3()}:~ Developer Item ~]");
+                TooltipLine developerLine = new(Mod, "Developer", Utilities.GetLocalization("Items.DeveloperItem").Format(devColor.Hex3()));
                 tooltips.Add(developerLine);
             }
         }
@@ -156,15 +154,16 @@ namespace InfernumMode.Core.GlobalInstances.GlobalItems
         public static void EditEnrageTooltips(Item item, List<TooltipLine> tooltips)
         {
             // Don't do anything if the item doesn't call for a tooltip replacement.
-            if (!EnrageTooltipReplacements.TryGetValue(item.type, out string tooltipReplacement))
+            if (!EnrageTooltipReplacements.TryGetValue(item.type, out LocalizedText tooltipReplacement))
                 return;
 
             // Don't do anything if the item has no enrage tooltip to reference.
-            var enrageTooltip = tooltips.FirstOrDefault(x => x.Text.Contains("enrage", StringComparison.OrdinalIgnoreCase));
+            string localizedEnrageText = Utilities.GetLocalization("Items.EnrageTooltip").Value.ToLower();
+            var enrageTooltip = tooltips.FirstOrDefault(x => x.Text.Contains(localizedEnrageText, StringComparison.OrdinalIgnoreCase));
             if (enrageTooltip is null)
                 return;
 
-            int enrageTextStart = enrageTooltip.Text.IndexOf("enrage", StringComparison.OrdinalIgnoreCase);
+            int enrageTextStart = enrageTooltip.Text.IndexOf(localizedEnrageText, StringComparison.OrdinalIgnoreCase);
             int enrageTextEnd = enrageTextStart;
 
             // Find where the current line terminates following the instance of the word 'enrage'.
@@ -175,7 +174,7 @@ namespace InfernumMode.Core.GlobalInstances.GlobalItems
 
             // If a replacement exists, insert it into the enrage text instead.
             if (tooltipReplacement is not null)
-                enrageTooltip.Text = enrageTooltip.Text.Insert(enrageTextStart, tooltipReplacement);
+                enrageTooltip.Text = enrageTooltip.Text.Insert(enrageTextStart, tooltipReplacement.Value);
             else
                 enrageTooltip.Text = enrageTooltip.Text.Replace("\n\n", "\n");
         }

--- a/Core/GlobalInstances/GlobalNPCDrawEffects.cs
+++ b/Core/GlobalInstances/GlobalNPCDrawEffects.cs
@@ -186,11 +186,11 @@ namespace InfernumMode.Core.GlobalInstances
                 return;
 
             if (npc.type == ModContent.NPCType<CalamitasClone>())
-                typeName = $"The {CalamitasShadowBehaviorOverride.CustomName}";
+                typeName = Utilities.GetLocalization("NameOverrides.CalamitasShadowClone.EntryName").Format(CalamitasShadowBehaviorOverride.CustomName);
             if (npc.type == ModContent.NPCType<Cataclysm>())
-                typeName = CalamitasShadowBehaviorOverride.CustomNameCataclysm;
+                typeName = CalamitasShadowBehaviorOverride.CustomNameCataclysm.Value;
             if (npc.type == ModContent.NPCType<Catastrophe>())
-                typeName = CalamitasShadowBehaviorOverride.CustomNameCatastrophe;
+                typeName = CalamitasShadowBehaviorOverride.CustomNameCatastrophe.Value;
         }
         #endregion Name Manipulation
     }

--- a/Core/GlobalInstances/Players/DebuffEffectsPlayer.cs
+++ b/Core/GlobalInstances/Players/DebuffEffectsPlayer.cs
@@ -69,11 +69,11 @@ namespace InfernumMode.Core.GlobalInstances.Players
             if (damage == 10.0 && hitDirection == 0 && damageSource.SourceOtherIndex == 8)
             {
                 if (RedElectrified)
-                    damageSource = PlayerDeathReason.ByCustomReason($"{Player.name} could not withstand the red lightning.");
+                    damageSource = PlayerDeathReason.ByCustomReason(Utilities.GetLocalization("Status.Death.RedElectrified").Format(Player.name));
                 if (DarkFlames)
-                    damageSource = PlayerDeathReason.ByCustomReason($"{Player.name} was incinerated by ungodly fire.");
+                    damageSource = PlayerDeathReason.ByCustomReason(Utilities.GetLocalization("Status.Death.DarkFlames").Format(Player.name));
                 if (Madness)
-                    damageSource = PlayerDeathReason.ByCustomReason($"{Player.name} went mad.");
+                    damageSource = PlayerDeathReason.ByCustomReason(Utilities.GetLocalization("Status.Death.Madness").Format(Player.name));
             }
             return true;
         }

--- a/Core/GlobalInstances/Systems/CustomExoMechSelectionSystem.cs
+++ b/Core/GlobalInstances/Systems/CustomExoMechSelectionSystem.cs
@@ -60,7 +60,8 @@ namespace InfernumMode.Core.GlobalInstances.Systems
                     ExoMechSelectionUI.HoverSoundMechType = null;
 
                 var font = FontAssets.MouseText.Value;
-                string pickTwoText = "Pick two. The first mech will be fought alone. Once sufficiently damaged, the second mech will be summoned and the two will fight together.";
+                //string pickTwoText = "Pick two. The first mech will be fought alone. Once sufficiently damaged, the second mech will be summoned and the two will fight together.";
+                string pickTwoText = Utilities.GetLocalization("ExoMechsFight.PickTwoText").Value;
                 Vector2 pickToDrawPosition = baseDrawPosition - Vector2.UnitY * 250f;
                 foreach (string line in Utils.WordwrapString(pickTwoText, font, 600, 10, out _))
                 {
@@ -91,20 +92,20 @@ namespace InfernumMode.Core.GlobalInstances.Systems
                 case 1:
                     iconScale = ExoMechSelectionUI.DestroyerIconScale;
                     iconMechTexture = ModContent.Request<Texture2D>("CalamityMod/UI/DraedonSummoning/HeadIcon_THanos").Value;
-                    description = "Thanatos, a serpentine terror with impervious armor and innumerable laser turrets.";
+                    description = Utilities.GetLocalization("ExoMechsFight.ThanatosDesc").Value;
                     hoverSound = ExoMechSelectionUI.ThanatosHoverSound;
                     break;
                 case 2:
                     iconScale = ExoMechSelectionUI.PrimeIconScale;
                     iconMechTexture = ModContent.Request<Texture2D>("CalamityMod/UI/DraedonSummoning/HeadIcon_Ares").Value;
-                    description = "Ares, a heavyweight, diabolical monstrosity with six Exo superweapons.";
+                    description = Utilities.GetLocalization("ExoMechsFight.AresDesc").Value;
                     hoverSound = ExoMechSelectionUI.AresHoverSound;
                     break;
                 case 3:
                 default:
                     iconScale = ExoMechSelectionUI.TwinsIconScale;
                     iconMechTexture = ModContent.Request<Texture2D>("CalamityMod/UI/DraedonSummoning/HeadIcon_ArtemisApollo").Value;
-                    description = "Artemis and Apollo, a pair of extremely agile destroyers with unstable energy reserves.";
+                    description = Utilities.GetLocalization("ExoMechsFight.ArtemisApolloDesc").Value;
                     hoverSound = ExoMechSelectionUI.TwinsHoverSound;
                     break;
             }

--- a/Core/ILEditingStuff/MechanicHooks.cs
+++ b/Core/ILEditingStuff/MechanicHooks.cs
@@ -77,7 +77,7 @@ namespace InfernumMode.Core.ILEditingStuff
         internal string RenameGSS(On_Lang.orig_GetNPCNameValue orig, int netID)
         {
             if (netID == ModContent.NPCType<GreatSandShark>() && InfernumMode.CanUseCustomAIs)
-                return GreatSandSharkBehaviorOverride.NewName;
+                return GreatSandSharkBehaviorOverride.NewName.Value;
 
             return orig(netID);
         }

--- a/Core/ILEditingStuff/VanillaCorrectionHooks.cs
+++ b/Core/ILEditingStuff/VanillaCorrectionHooks.cs
@@ -1289,7 +1289,8 @@ namespace InfernumMode.Core.ILEditingStuff
         {
             orig(npc, ref typeName);
             if (npc.type == ModContent.NPCType<CalamitasClone>() && InfernumMode.CanUseCustomAIs)
-                typeName = $"The {CalamitasShadowBehaviorOverride.CustomName}";
+                //typeName = $"The { CalamitasShadowBehaviorOverride.CustomName.Value }";
+                typeName = Utilities.GetLocalization("NameOverrides.CalamitasShadowClone.EntryName").Format(CalamitasShadowBehaviorOverride.CustomName);
         }
     }
 

--- a/Localization/en-US.hjson
+++ b/Localization/en-US.hjson
@@ -28,6 +28,32 @@ Mods: {
 			AchievementsLabelText: Next
 			WishesHeader: Dev Wishes
 			WishesHoverTextButton: Open Death Wishes
+
+			GuardiansPlaqueUI: {
+				HoverText: Read
+				// !! Beware translators: The "ancient artifact" string must be the same as the one in the SpecialText
+				PlaqueText: Three disciples. One mind. One deity. One purpose. Tempered by the holy flames of Providence, an ancient artifact is crystalized, with the sole purpose of initiating the Ritual at the cliff of this Temple.
+				SpecialText: ancient artifact
+			}
+
+			// Enrage tooltips
+			EnrageTooltipReplacements: {
+				DecapoditaSprout: Enrages outside of the Mushroom biome
+				WormFood: Enrages outside of the Corruption
+				BloodySpine: Enrages outside of the Crimson
+				Teratoma: Enrages outside of the Corruption
+				BloodyWormFood: Enrages outside of the Crimson
+				Seafood: Enrages outside of the waters of the Sulphurous Sea
+				Abombination: Enrages outside of the Underground Jungle
+				NecroplasmicBeacon: Enrages outside of the Underground
+			}
+		}
+
+		Bestiary: {
+			BereftVassal: A vigilant guardian, once wandering without a purpose. Having learned that his king lives on, it'd seem that he has started to regain his will to live. He looks forward to fighting you again.
+			DepthFeeder: Even in the overwhelmingly hostile environment of the Abyss, ecosystems may flourish.
+			Herring: Unusually hardy, these creatures somehow flourish in the toxic upper abyssal caverns. Regardless, they are at the bottom of the food chain.
+			Lionfish: These rugged fish are seldom hunted in their natural habitats, relying heavily on their venomous spines for both offense and defense.
 		}
 
 		IntroScreen: {
@@ -1143,7 +1169,17 @@ Mods: {
 			ExplodingServant.DisplayName: Servant of Cthulhu
 			GolemFistLeft.DisplayName: Golem Fist
 			GolemFistRight.DisplayName: Golem Fist
-			BereftVassal.DisplayName: Argus, the Bereft Vassal
+
+			BereftVassal: {
+				DisplayName: Argus, the Bereft Vassal
+
+				BossChecklistIntegration: {
+					SpawnInfo: Use a [i:7119] at the pedestal in the heart of the desert.
+					EntryName: Bereft Vassal
+				}
+			}
+
+			GreatSandShark.DisplayName: Taurus, the Great Sand Shark
 			Ninja.DisplayName: Ninja
 			BuilderDroneBig.DisplayName: Big Builder Drone
 			BuilderDroneSmall.DisplayName: Small Builder Drone
@@ -1158,7 +1194,13 @@ Mods: {
 			SplitBigSlimeAnimation.DisplayName: Unstable Slime Spawn
 			ShadowDemon.DisplayName: Shadow Hydra
 			GolemArenaPlatform.DisplayName: Golem Arena Platform
+			CalamitasShadowClone.DisplayName: Forgotten Shadow of Calamitas
+			CataclysmShadow.DisplayName: Forgotten Shadow of Cataclysm
+			CatastropheShadow.DisplayName: Forgotten Shadow of Catastrophe
 		}
+
+		// Will use the CalamitasShadowClone.DisplayName field
+		NameOverrides.CalamitasShadowClone.EntryName: The {0}
 
 		Biomes: {
 			LostColosseumBiome: {
@@ -1255,6 +1297,11 @@ Mods: {
 		}
 
 		Items: {
+			// Beware translators, this line must match the "enrage" word in the tooltip of your language
+			EnrageTooltip: enrage
+			DeveloperItem: "[c/{0}:~ Developer Item ~]"
+			InfernalRelicText: Imbued with the infernal flames of a defeated foe
+
 			Lore: {
 				KnowledgeBereftVassal: {
 					Lore:
@@ -1267,6 +1314,38 @@ Mods: {
 					DisplayName: Knowledge Bereft Vassal
 				}
 			}
+
+			CelestialSigil.SummoningText:
+				'''
+				Summons the Moon Lord immediately
+				Creates an arena at the player's position
+				Not consumable
+				'''
+
+			ProfanedShard: {
+				SummoningText: Summons the Profaned Guardians when used on the cliff in the profaned garden at the far right of the underworld during day
+				GardenWarning:
+					'''
+					Your world does not currently have a Profaned Garden. Kill the Moon Lord again to generate it
+					Be sure to grab the Hell schematic first if you do this, as the garden might destroy the lab
+					'''
+			}
+
+			EyeofDesolation.SummoningText: Summons the {0} when used during nighttime
+			ProfanedCore.SummoningText: Summons Providence when used at the altar in the profaned temple at the far right of the underworld
+			RuneofKos.DeveloperText: The Ceaseless Void can only be fought in the Archives
+
+			SandstormsCore: {
+				PortalDetail: Opens a portal to the Lost Colosseum
+				GatewayWarning: Your world does not currently have a Lost Gateway. Kill the Lunatic Cultist again to generate it.
+			}
+
+			LihzahrdPowerCell.SummoningText:
+				'''
+				Summons Golem when used at the Lihzhard Altar
+				Golem summons a rectangular arena around the altar
+				If the altar is inside of the temple solid tiles within the arena are broken
+				'''
 
 			CherishedSealocket: {
 				DisplayName: Cherished Sealocket
@@ -1296,11 +1375,21 @@ Mods: {
 
 			SakuraBloom: {
 				DisplayName: Sakura Bloom
+				// Important: Don't translate this tooltip, currently is being used for the tooltip effect
 				Tooltip:
 					'''
 					A symbol of how beautiful love is when in bloom, and how easily it can wither away whyyyy
 					Temporary
 					'''
+
+				TooltipEffect: {
+					FirstText: "A symbol of how beautiful "
+					SecondText: love
+					ThirdText: " is when it’s in bloom, and yet how easily it can wither away"
+					FourthText: "Maybe with this, we can hold onto the "
+					FifthText: memories
+					SixthText: ?
+				}
 			}
 
 			BereftVassalBossBag: {
@@ -1521,11 +1610,30 @@ Mods: {
 			DevourerOfGodsRelic: {
 				DisplayName: Infernal Devourer of Gods Relic
 				Tooltip: GetsChanged
+				PersonalMessage:
+					'''
+					Sometimes pure reaction skill is the most valuable thing to cultivate.
+					You are in the final stretch. Your determination has proven invaluable up to this point.
+					May it guide you through the last challenges.
+					'''
 			}
 
 			DraedonRelic: {
 				DisplayName: Infernal Draedon Relic
 				Tooltip: GetsChanged
+
+				PersonalMessage: {
+					DefaultMessage:
+						'''
+						You have done phenomenally. There is only one challenge left now-
+						Face the Witch.
+						'''
+					DownedCalamitasMessage:
+						'''
+						Spectacular work. You have conquered all of the major obstacles.
+						Take pride in this accomplishment, for you are considerably stronger than you were when you began.
+						'''
+				}
 			}
 
 			DragonfollyRelic: {
@@ -1551,11 +1659,17 @@ Mods: {
 			EmpressOfLightRelic: {
 				DisplayName: Infernal Empress of Light Relic
 				Tooltip: GetsChanged
+				PersonalMessage: The optional foes may at times be the most formidable. So too may they yield the greatest rewards.
 			}
 
 			EyeOfCthulhuRelic: {
 				DisplayName: Infernal Eye of Cthulhu Relic
 				Tooltip: GetsChanged
+				PersonalMessage:
+					'''
+					Remember to not force yourself too much in the pursuit of victory. Take breaks if you need to.
+					The most important thing is fun.
+					'''
 			}
 
 			ForgottenShadowOfCalamitasRelic: {
@@ -1571,6 +1685,7 @@ Mods: {
 			GolemRelic: {
 				DisplayName: Infernal Golem Relic
 				Tooltip: GetsChanged
+				PersonalMessage: Simple methodical planning goes a long way. It will be invaluable against future obstacles.
 			}
 
 			HiveMindRelic: {
@@ -1581,6 +1696,7 @@ Mods: {
 			KingSlimeRelic: {
 				DisplayName: Infernal King Slime Relic
 				Tooltip: GetsChanged
+				PersonalMessage: Even seasoned players may struggle somewhat in the face of something new and unfamiliar. Adaptability is key.
 			}
 
 			LeviathanRelic: {
@@ -1596,6 +1712,11 @@ Mods: {
 			MoonLordRelic: {
 				DisplayName: Infernal Moon Lord Relic
 				Tooltip: GetsChanged
+				PersonalMessage:
+					'''
+					You have done very well thus far.
+					May your tenacity guide you through the remaining challenges.
+					'''
 			}
 
 			OgreRelic: {
@@ -1606,6 +1727,11 @@ Mods: {
 			OldDukeRelic: {
 				DisplayName: Infernal Old Duke Relic
 				Tooltip: GetsChanged
+				PersonalMessage:
+					'''
+					Difficult as the fight may be, you were wise to endure and overcome the challenge it brings.
+					You will find that the mechanics it tested will be relevant again soon.
+					'''
 			}
 
 			PerforatorsRelic: {
@@ -1621,6 +1747,11 @@ Mods: {
 			PlanteraRelic: {
 				DisplayName: Infernal Plantera Relic
 				Tooltip: GetsChanged
+				PersonalMessage:
+					'''
+					Be proud of your death count!
+					The more you die, the more you're learning. Keep going!
+					'''
 			}
 
 			PolterghastRelic: {
@@ -1636,6 +1767,19 @@ Mods: {
 			ProvidenceRelic: {
 				DisplayName: Infernal Providence Relic
 				Tooltip: GetsChanged
+
+				PersonalMessage: {
+					DefaultMessage:
+						'''
+						The first major hurdle following the defeat of the Moon Lord. Your triumph over her was by no means a small feat.
+						Perhaps consider fighting her again during the night for a special challenge?
+						'''
+					HasBeatenInfernumNightProvBeforeDayMessage:
+						'''
+						Bruh? What the heck? Are you OK?
+						            You were supposed to fight her at night AFTER beating her during the day first!
+						'''
+				}
 			}
 
 			QueenBeeRelic: {
@@ -1666,6 +1810,7 @@ Mods: {
 			SkeletronRelic: {
 				DisplayName: Infernal Skeletron Relic
 				Tooltip: GetsChanged
+				PersonalMessage: The first major roadblock. You are better now than before you faced it. Did you have fun learning its patterns?
 			}
 
 			SlimeGodRelic: {
@@ -1681,6 +1826,19 @@ Mods: {
 			SupremeCalamitasRelic: {
 				DisplayName: Infernal Supreme Calamitas Relic
 				Tooltip: GetsChanged
+
+				PersonalMessage: {
+					DefaultMessage:
+						'''
+						You have done phenomenally. There is only one challenge left now-
+						Face the Cosmic Engineer.
+						'''
+					DownedExoMechsMessage:
+						'''
+						Spectacular work. You have conquered all of the major obstacles.
+						Take pride in this accomplishment, for you are considerably stronger than you were when you began.
+						'''
+				}
 			}
 
 			TwinsRelic: {
@@ -1706,6 +1864,15 @@ Mods: {
 					You feel a guiding spirit trying to lead you the bloom’s home
 					Maybe you should follow its call?
 					'''
+
+				TooltipEffect: {
+					FirstText: "You feel a "
+					SecondText: guiding spirit
+					ThirdText: " trying to lead you the bloom’s home"
+					FourthText: "The spirit is trying to draw your attention to the "
+					FifthText: water
+					SixthText: Maybe you should follow its call?
+				}
 			}
 
 			BloodwormPlatter: {
@@ -1816,6 +1983,12 @@ Mods: {
 					Does not work when a boss is alive
 					ModifedInModifyTooltips
 					'''
+				TooltipEffect:
+					'''
+					Hold LMB to teleport to the gate
+					Hold LMB and {0} to set the gate to your position
+					Hold LMB and {1} to remove the gate
+					'''
 			}
 
 			AridBattlecry: {
@@ -1842,6 +2015,12 @@ Mods: {
 					You shouldn't see this
 					Its existence compels one to wonder what knowledge has been lost to the mysterious, watery depths
 					'''
+
+				TooltipEffect: {
+					FirstText: "An "
+					SecondText: "incomprehensibly "
+					ThirdText: old tome. Somehow, in spite of its supposed age, it appears to be completely unscathed
+				}
 			}
 
 			Kevin: {
@@ -1934,12 +2113,12 @@ Mods: {
 			ProfanedGardenLocationSetter: {
 				DisplayName: Profaned Garden Location Setter
 				Tooltip:
-				'''
-				Use this to fix the profaned garden not functioning properly.
-				Left click the bottom-center of the Profaned Plaque tile in the middle of the garden.
-				This will center the garden position around that point correctly.
-				ou can right click to revert the position to the previous one.
-				'''
+					'''
+					Use this to fix the profaned garden not functioning properly.
+					Left click the bottom-center of the Profaned Plaque tile in the middle of the garden.
+					This will center the garden position around that point correctly.
+					ou can right click to revert the position to the previous one.
+					'''
 			}
 		}
 
@@ -1989,6 +2168,13 @@ Mods: {
 					Tooltip: Enables boss footage recordings for the playback during the credits.
 				}
 			}
+		}
+
+		ExoMechsFight: {
+			PickTwoText: Pick two. The first mech will be fought alone. Once sufficiently damaged, the second mech will be summoned and the two will fight together.
+			ThanatosDesc: Thanatos, a serpentine terror with impervious armor and innumerable laser turrets.
+			AresDesc: Ares, a heavyweight, diabolical monstrosity with six Exo superweapons.
+			ArtemisApolloDesc: Artemis and Apollo, a pair of extremely agile destroyers with unstable energy reserves.
 		}
 
 		Status: {
@@ -2051,6 +2237,13 @@ Mods: {
 			DraedonDefeat9: But now, I must return to my machinery. You may use the Codebreaker if you wish to face my creations once again.
 			DraedonDefeat10: In the meantime, I bid you farewell, and good luck in your future endeavors.
 			SCalCongratulations: ... Congratulations.
+
+			Death: {
+				RedElectrified: "{0} could not withstand the red lightning."
+				DarkFlames: "{0} was incinerated by ungodly fire."
+				Madness: "{0} went mad."
+				HyperplaneMatrixExplosion: "{0} was blown up."
+			}
 		}
 
 		PetDialog: {


### PR DESCRIPTION
Added/Changed the following stuff to use localized texts instead of code-written strings:
- Infernal Relic tooltips
- Bestiary entries
- BossAIs boss renaming
- Custom Developer-tier item tooltips (the colored ones)
- Death status messages
- Profaned Garden Plaque texts
- Exo Mechs boss selection texts

This should help third-party translators with their translation mod projects.